### PR TITLE
plot_operator 1.0.10: bump base_memory and ratio to fix OOM

### DIFF
--- a/operator_resource_settings_custom.json
+++ b/operator_resource_settings_custom.json
@@ -94,5 +94,11 @@
     "version": "0.3.0",
     "base_memory": 5000000000,
     "ratio": 5
+  },
+  {
+    "uri": "https://github.com/tercen/plot_operator",
+    "version": "1.0.10",
+    "base_memory": 1000000000,
+    "ratio": 6
   }
 ]


### PR DESCRIPTION
## Summary

Three production OOM kills today on Sartorius (Plot 1.0.10 on the `phenotype_template_for_gs01` workflow) at 367k / 6.4M / 51M qt rows. The default formula (base 500 MB, ratio 5) was consistently 4 % short of the actual cgroup peak — enough for the kernel OOM-killer to fire on every run.

## Empirical fit

| qt_rows | observed peak | bytes/row above ~1.1 GB intercept |
| --- | --- | --- |
| 367k | 671 MB | ~200 (small-data noise) |
| 6.4M | 2,970 MB | ~290 |
| 51M | 16,050 MB | ~290 |

i.e. `peak ≈ 1.1 GB + 0.29 KB/row × n_main`. Translated to the legacy `(base, ratio)` units (qt has ~78 bytes/row in Plot's `getValues`), that's roughly `base 1.1 GB + ratio 3.7`.

Picked **`base_memory = 1 GB, ratio = 6`** to cover the 4 % systematic under-estimate plus typical ggplot2 layer variability, with a 1 GB floor above the empirical intercept.

## Predicted vs observed

| qt_rows | predicted (1 GB + 6 × size) | actual peak | margin |
| --- | --- | --- | --- |
| 367k | 1,172 MB | 671 MB | +75 % |
| 6.4M | 3,856 MB | 2,970 MB | +30 % |
| 51M | 18,898 MB | 16,050 MB | +18 % |

Headroom consistent across two orders of magnitude.

## Long-term

A `memory_model.json` was committed to `tercen/plot_operator` master ([commit](https://github.com/tercen/plot_operator/commit/43e0ccf)) so the power-law model will travel with the operator. This manual override is the stop-gap that takes effect on the next 5-min env-cache refresh — once a `1.0.11` release ships and is reinstalled, the manual entry can be dropped.

## Test plan

- [ ] Wait for the env cache TTL (≤ 5 min) on Sartorius after merge
- [ ] Re-run the failed `tSNE & marker expression` step; verify it no longer OOMs
- [ ] Confirm `stats_d_estimated_ram` matches the new `base + ratio × size` numbers above