### PR TITLE
plot_operator 1.0.10: add resource settings entry to auto file

### DIFF
--- a/operator_resource_settings_auto.json
+++ b/operator_resource_settings_auto.json
@@ -1663,7 +1663,7 @@
         "ratio_upper": -0.1234,
         "r2": 0.4854,
         "typical_duration": 13.8,
-        "ratio_rounded": -0,
+        "ratio_rounded": 0,
         "ratio": 5
     },
     {
@@ -3392,5 +3392,11 @@
         "typical_duration": 4.5,
         "ratio_rounded": -4.6,
         "ratio": 5
+    },
+    {
+        "uri": "https://github.com/tercen/plot_operator",
+        "version": "1.0.10",
+        "base_memory": 1000000000,
+        "ratio": 6
     }
 ]


### PR DESCRIPTION
Follow-up to #335. The custom override there was silently dropped because the merge logic in `operator_service.dart:1075-1080` only honours custom entries that **already exist** in the auto file:

\`\`\`dart
for (var o in await _getOperatorsEnv(uriCustom)) {
  if (set.contains(o)) {
    set.remove(o);
    set.add(o);
  }
}
\`\`\`

plot_operator 1.0.10 wasn't in `operator_resource_settings_auto.json` (latest entry there was 0.1.6), so the custom entry from #335 has zero effect — Tercen falls back to global defaults (base 500 MB, ratio 5) and OOMs continue on Sartorius.

This PR adds the entry directly to the auto file with the values agreed in #335: base 1 GB, ratio 6.

Once the env-cache TTL elapses (5 min) the new estimates kick in:

| qt_rows | sizeInBytes | predicted | observed peak |
| --- | --- | --- | --- |
| 367k | 28.6 MB | 1.17 GB | 671 MB (+75%) |
| 6.4M | 476 MB | 3.86 GB | 2.97 GB (+30%) |
| 51M | 2.98 GB | 18.9 GB | 16.05 GB (+18%) |

Sibling note: the `if (set.contains(o))` check is itself a separate bug — custom-only entries (entries not present in auto) should be honoured too. That's a code change in tercen and out of scope here, but worth filing.

## Test plan

- [ ] Wait 5 min after merge for env cache TTL
- [ ] Re-run the failed `tSNE & marker expression` step on Sartorius
- [ ] Verify `stats_d_estimated_ram` ≈ 1.17 GB instead of 643 MB