### PR TITLE
plot_operator 1.0.10: bump base_memory to 2 GB and ratio to 7

### DIFF
--- a/operator_resource_settings_auto.json
+++ b/operator_resource_settings_auto.json
@@ -3396,7 +3396,7 @@
     {
         "uri": "https://github.com/tercen/plot_operator",
         "version": "1.0.10",
-        "base_memory": 1000000000,
-        "ratio": 6
+        "base_memory": 2000000000,
+        "ratio": 7
     }
 ]

--- a/operator_resource_settings_custom.json
+++ b/operator_resource_settings_custom.json
@@ -17,7 +17,7 @@
     "base_memory": 5000000000,
     "ratio": 10
   },
-   {
+  {
     "uri": "https://github.com/tercen/fast_tSNE_operator",
     "version": "0.1.6",
     "base_memory": 5000000000,
@@ -98,7 +98,7 @@
   {
     "uri": "https://github.com/tercen/plot_operator",
     "version": "1.0.10",
-    "base_memory": 1000000000,
-    "ratio": 6
+    "base_memory": 2000000000,
+    "ratio": 7
   }
 ]


### PR DESCRIPTION
Follow-up to #335 / #336. Today's 51M-row Plot run on a different workflow peaked at **19.74 GB** — 23 % higher than yesterday's 16.05 GB on the same row count, due to different label/color/axis configuration. The 18.9 GB cgroup limit from \`(base 1 GB, ratio 6)\` was 840 MB short and the operator was kernel-OOM-killed.

## New values

| qt_rows | sizeInBytes | predicted (2 GB + 7 × size) | observed peak | margin |
| --- | --- | --- | --- | --- |
| 367k | 28.6 MB | 2.20 GB | 671 MB | +228 % |
| 6.4M | 476 MB | 5.33 GB | 2.97 GB | +80 % |
| 51M | 2,983 MB | **22.88 GB** | 19.74 GB | **+16 %** |

The small-data over-estimate is the trade-off for safety on the 51M case. Step-level \`ram\` overrides are still available for users who want to pack more small Plot tasks per worker.

## Why two files

Both \`operator_resource_settings_auto.json\` and \`operator_resource_settings_custom.json\` are updated in lock-step. Per \`operator_service.dart:1075-1080\`, custom entries only take effect when the same \`(uri, version)\` exists in auto. Keeping them aligned makes either file authoritative if the merge logic is ever refactored.

## Test plan

- [ ] Wait 5 min after merge for env cache TTL
- [ ] Re-run the failed step on Sartorius (51M-row Plot)
- [ ] Verify \`stats_d_estimated_ram\` ≈ 22.88 GB
- [ ] Confirm peak < 22.88 GB (no OOM)