### PR TITLE
plot_operator 1.0.10: bump ratio from 7 to 8

### DIFF
--- a/operator_resource_settings_auto.json
+++ b/operator_resource_settings_auto.json
@@ -3397,6 +3397,6 @@
         "uri": "https://github.com/tercen/plot_operator",
         "version": "1.0.10",
         "base_memory": 2000000000,
-        "ratio": 7
+        "ratio": 8
     }
 ]

--- a/operator_resource_settings_custom.json
+++ b/operator_resource_settings_custom.json
@@ -99,6 +99,6 @@
     "uri": "https://github.com/tercen/plot_operator",
     "version": "1.0.10",
     "base_memory": 2000000000,
-    "ratio": 7
+    "ratio": 8
   }
 ]


### PR DESCRIPTION
Follow-up to #337. The previous (2 GB, 7) values just barely covered today's 51M-row Plot run — predicted 22.88 GB, observed 21.81 GB, 5 % margin. Plot's run-to-run peak variance is ~10 % on identical n_main (19.74 GB → 21.81 GB on consecutive runs), so the previous tuning was one noisy run away from another OOM.

Bumping ratio 7 → 8 gives the 51M case 25.86 GB:

| qt_rows | predicted | observed | margin |
| --- | --- | --- | --- |
| 367k | 2.23 GB | 671 MB | +232 % |
| 6.4M | 5.81 GB | 2.97 GB | +96 % |
| 51M | 25.86 GB | 19.74-21.81 GB | +18-31 % |