### PR TITLE
plot_operator: bump manual list to 1.0.11

### DIFF
--- a/tercen/library-manual.json
+++ b/tercen/library-manual.json
@@ -10,7 +10,7 @@
       "url": "https://github.com/tercen/export_operator"
     },
     {
-      "version": "1.0.10",
+      "version": "1.0.11",
       "url": "https://github.com/tercen/plot_operator"
     },
     {


### PR DESCRIPTION
1.0.11 ships:

- \`memory_model.json\` (linear in \`n_main\`, 600 MB R baseline) so the operator carries its own memory estimate instead of falling through to the legacy formula.
- \`drop = TRUE\` on facet_grid / facet_wrap (utils.R) so plots are sized to the populated (.ri, .ci) combinations rather than the schema's full row × col cardinality. Resolves \"Dimensions exceed 50 inches\" failures when row/col axes are wide but per-page data subsets populate only a fraction.
- 1000-cell cap is now scoped to \`split_cells = TRUE\` only (the branch where each cell becomes a zip entry). Paged plots aren't artificially blocked.
- renv.lock regenerated against cloud.r-project.org and GitHub-pinned tercen-internal packages because cran.tercen.com is currently down (PACKAGES index returns 404).

Once the next library cron run picks this up, the manual entries we added in \`operator_resource_settings_*.json\` (#335, #336, #337, #338) become harmless — the operator's own \`memory_model.json\` takes precedence — and can be cleaned up in a follow-up PR.