### PR TITLE
plot_operator: bump manual list to 1.0.12

### DIFF
--- a/tercen/library-manual.json
+++ b/tercen/library-manual.json
@@ -10,7 +10,7 @@
       "url": "https://github.com/tercen/export_operator"
     },
     {
-      "version": "1.0.11",
+      "version": "1.0.12",
       "url": "https://github.com/tercen/plot_operator"
     },
     {


### PR DESCRIPTION
## Summary
- 1.0.11 install pulled the stale `:1.0.10` image (operator.json had the container tag hardcoded), so the cell-cap gating + `drop = TRUE` facet fix never reached production.
- Fixed upstream in plot_operator master + tag 1.0.12 — operator.json now uses `ghcr.io/tercen/plot_operator` (no tag), so Tercen appends the install version automatically.

## Test plan
- [ ] Library install picks up 1.0.12 on Sartorius
- [ ] Re-run failed "tSNE & clusters by well" step in `phenotype_template_for_gs01`

🤖 Generated with [Claude Code](https://claude.com/claude-code)