### PR TITLE
plot_operator: bump manual list to 1.0.13

### DIFF
--- a/tercen/library-manual.json
+++ b/tercen/library-manual.json
@@ -10,7 +10,7 @@
       "url": "https://github.com/tercen/export_operator"
     },
     {
-      "version": "1.0.12",
+      "version": "1.0.13",
       "url": "https://github.com/tercen/plot_operator"
     },
     {


### PR DESCRIPTION
## Summary
- Multi-stage Dockerfile on \`runtime-r44-minimal-plot:4.4.3-2\` — no renv at runtime
- Image size 3.5GB → 301MB
- Jemalloc preloaded, ragg for X11-free PNG output
- Fixes the \"missing entries in the cache\" runtime error that 1.0.12 hit

## Test plan
- [x] Local build + smoke test of png/pdf/svg ggsave
- [ ] LibraryTask installs cleanly on Sartorius
- [ ] Re-run \"tSNE & clusters by well\" step succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)