### PR TITLE
plot_operator: bump manual list to 1.0.14

### DIFF
--- a/tercen/library-manual.json
+++ b/tercen/library-manual.json
@@ -10,7 +10,7 @@
       "url": "https://github.com/tercen/export_operator"
     },
     {
-      "version": "1.0.13",
+      "version": "1.0.14",
       "url": "https://github.com/tercen/plot_operator"
     },
     {


### PR DESCRIPTION
Restore operator.json in the runtime stage — utils.R reads it at run time for property defaults. 1.0.13 dropped it and failed at runtime.