### PR TITLE
plot_operator: bump manual list to 1.0.15

### DIFF
--- a/tercen/library-manual.json
+++ b/tercen/library-manual.json
@@ -10,7 +10,7 @@
       "url": "https://github.com/tercen/export_operator"
     },
     {
-      "version": "1.0.14",
+      "version": "1.0.15",
       "url": "https://github.com/tercen/plot_operator"
     },
     {


### PR DESCRIPTION
Adds limitsize=FALSE to ggsave for many-cell crosstabs.