### PR TITLE
plot_operator: bump manual list to 1.0.16

### DIFF
--- a/tercen/library-manual.json
+++ b/tercen/library-manual.json
@@ -10,7 +10,7 @@
       "url": "https://github.com/tercen/export_operator"
     },
     {
-      "version": "1.0.15",
+      "version": "1.0.16",
       "url": "https://github.com/tercen/plot_operator"
     },
     {


### PR DESCRIPTION
Adds limit_size property; CI now publishes both commit SHA and annotated tag SHA so install works without manual retag.