### PR TITLE
plot_operator: bump manual list to 1.0.17

### DIFF
--- a/tercen/library-manual.json
+++ b/tercen/library-manual.json
@@ -10,7 +10,7 @@
       "url": "https://github.com/tercen/export_operator"
     },
     {
-      "version": "1.0.16",
+      "version": "1.0.17",
       "url": "https://github.com/tercen/plot_operator"
     },
     {


### PR DESCRIPTION
Memory model bump to fix OOM at 6.43M-row crosstabs.